### PR TITLE
Illustrate layout in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ In Linux, set compose to pause, switch lang to rctrl.
 Instructions on what to do with the 'custom' and 'evdev' files are in those files. Copy the contents of my ZMK keymap file, found here: https://github.com/stozi/zmk-config/blob/master/config/a_dux.keymap to yours in Github. ZMK mouse keys require additional setup. If ZMK mouse keys are still in beta and you haven't got it working yet, you can copy the contents of my west.yml file: https://github.com/stozi/zmk-config/blob/master/config/west.yml.
 
 
-Open this readme raw to view layout illustration with correct spacing, some chars displayed wrong otherwise. Prefix 'ct' or 'c' 
-means ctrl+...
+Prefix 'ct' or 'c' means ctrl+...
 
 Illustration:
 
 Base layer, mouse keys on the left.
 
+```
 8   9<  0>  1&  2     3   4   5   6   7!
 
 ml  mu  md  mr  rmb   tab al  ad  au  ar
@@ -20,10 +20,11 @@ mmb v-  v+  lmb ,     .   hm  pd  pu  ed
                 ctl
 
 layer2 layer1/enter  shift/space alt/bkspc   
-               
+```               
 
 Hybrid ctrl/fn layer for base layer
 
+```
 f8  f9  f0  f1  f2    f3  f4  f5  f6  f7
 
 [{  whu whd ]}  f11   esc cal cad cau car
@@ -32,8 +33,9 @@ f8  f9  f0  f1  f2    f3  f4  f5  f6  f7
                 ctl
 
 nul layer0/enter  shift/space alt/del   
+```
 
-
+```
 p   l   d   g   v     z   k   o   u   -_
 
 n   r   t   s   w     y   h   e   i   a
@@ -41,10 +43,11 @@ n   r   t   s   w     y   h   e   i   a
 q   j   m   c   x     b   f   '"  ,?  ./
 
 layer0 layer3/enter  shift/space alt/bkspc   
-
+```
 
 Hybrid ctrl/fn layer for alpha layer. Here, nerts chars are below Russian. ^ is compose, L switch lang. You probably don't need F9 and ctrl-enter here like I do.
 
+```
 ctp ctl ^   L   ctv   ctz Ъ   cto ctu -
                           =+
 
@@ -55,3 +58,4 @@ ctq F9  ctE  ctc ctx   ctb ctf "   ?   Ё
                                @   !   –—
 
 null layer3/enter  shift/space alt/del   
+```


### PR DESCRIPTION
No need to open the README in raw format. It is best to use a monospace code block if spacing matters.